### PR TITLE
feat: add Hooks Extension Framework tooling for filters #2

### DIFF
--- a/openedx_filters/__init__.py
+++ b/openedx_filters/__init__.py
@@ -1,5 +1,5 @@
 """
-Events of the openedx platform.
+Filters of the Open edX platform.
 """
 
 __version__ = "0.1.0"

--- a/openedx_filters/exceptions.py
+++ b/openedx_filters/exceptions.py
@@ -1,0 +1,38 @@
+"""
+Exceptions thrown by filters.
+"""
+
+
+class HookFilterException(Exception):
+    """
+    Base exception for filters.
+
+    It is re-raised by the Pipeline Runner if any filter that is
+    executing raises it.
+
+    Arguments:
+        message (str): message describing why the exception was raised.
+        redirect_to (str): redirect URL.
+        status_code (int): HTTP status code.
+        keyword arguments (kwargs): extra arguments used to customize
+        exception.
+    """
+
+    def __init__(self, message="", redirect_to=None, status_code=None, **kwargs):
+        """
+        Init method for HookFilterException.
+
+        It's designed to allow flexible instantiation through **kwargs.
+        """
+        super().__init__()
+        self.message = message
+        self.redirect_to = redirect_to
+        self.status_code = status_code
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+    def __str__(self):
+        """
+        Show string representation of HookFilterException using its message.
+        """
+        return "HookFilterException: {}".format(self.message)

--- a/openedx_filters/pipeline.py
+++ b/openedx_filters/pipeline.py
@@ -1,0 +1,89 @@
+"""
+Pipeline runner used to execute list of functions (actions or filters).
+"""
+from logging import getLogger
+
+from .exceptions import HookFilterException
+from .utils import get_functions_for_pipeline, get_pipeline_configuration
+
+log = getLogger(__name__)
+
+
+def run_pipeline(hook_name, *args, **kwargs):
+    """
+    Execute filters in order.
+
+    Given a list of functions paths, this function will execute
+    them using the Accumulative Pipeline pattern defined in
+    docs/decisions/0003-hooks-filter-tooling-pipeline.rst
+
+    Example usage:
+        result = run_pipeline(
+            'org.openedx.service.subject.filter.action.major_version',
+            raise_exception=True,
+            request=request,
+            user=user,
+        )
+        >>> result
+       {
+           'result_test_1st_function': 1st_object,
+           'result_test_2nd_function': 2nd_object,
+       }
+
+    Arguments:
+        hook_name (str): determines which trigger we are listening to.
+        It also specifies which hook configuration defined through settings.
+
+    Returns:
+        out (dict): accumulated outputs of the functions defined in pipeline.
+        result (obj): return object of one of the pipeline functions. This will
+        be the returned by the pipeline if one of the functions returns
+        an object different than Dict or None.
+
+    Exceptions raised:
+        HookFilterException: custom exception re-raised when a function raises
+        an exception of this type and raise_exception is set to True. This
+        behavior is common when using filters.
+
+    This pipeline implementation was inspired by: Social auth core. For more
+    information check their Github repository:
+    https://github.com/python-social-auth/social-core
+    """
+    pipeline, raise_exception = get_pipeline_configuration(hook_name)
+
+    if not pipeline:
+        return kwargs
+
+    functions = get_functions_for_pipeline(pipeline)
+
+    out = kwargs.copy()
+    for function in functions:
+        try:
+            result = function(*args, **out) or {}
+            if not isinstance(result, dict):
+                log.info(
+                    "Pipeline stopped by '%s' for returning an object.",
+                    function.__name__,
+                )
+                return result
+            out.update(result)
+        except HookFilterException as exc:
+            if raise_exception:
+                log.exception(
+                    "Exception raised while running '%s':\n %s", function.__name__, exc,
+                )
+                raise
+        except Exception as exc:  # pylint: disable=broad-except
+            # We're catching this because we don't want the core to blow up
+            # when a hook is broken. This exception will probably need some
+            # sort of monitoring hooked up to it to make sure that these
+            # errors don't go unseen.
+            log.exception(
+                "Exception raised while running '%s': %s\n%s",
+                function.__name__,
+                exc,
+                "Continuing execution.",
+            )
+            continue
+
+    return out

--- a/openedx_filters/tests/__init__.py
+++ b/openedx_filters/tests/__init__.py
@@ -1,0 +1,3 @@
+"""
+Test package for filters from the Hooks Extension Framework.
+"""

--- a/openedx_filters/tests/test_exceptions.py
+++ b/openedx_filters/tests/test_exceptions.py
@@ -1,0 +1,25 @@
+"""
+Tests for custom Hooks Exceptions.
+"""
+from django.test import TestCase
+
+from ..exceptions import HookFilterException
+
+
+class TestCustomHookFilterException(TestCase):
+    """
+    Test class used to check flexibility when using  HookFilterException.
+    """
+
+    def test_exception_extra_arguments(self):
+        """
+        This method raises HookFilterException with custom dynamic arguments.
+
+        Expected behavior:
+            Custom parameters can be accessed as instance arguments.
+        """
+        hook_exception = HookFilterException(custom_arg="custom_argument")
+
+        self.assertEqual(
+            hook_exception.custom_arg, "custom_argument",  # pylint: disable=no-member
+        )

--- a/openedx_filters/tests/test_pipeline.py
+++ b/openedx_filters/tests/test_pipeline.py
@@ -1,0 +1,214 @@
+"""
+Tests for pipeline runner used by filters.
+"""
+from unittest.mock import Mock, patch
+
+from django.test import TestCase
+
+from ..exceptions import HookFilterException
+from ..pipeline import run_pipeline
+
+
+class TestRunningPipeline(TestCase):
+    """
+    Test class to verify standard behavior of the Pipeline runner.
+    """
+
+    def setUp(self):
+        """
+        Setup common conditions for every test case.
+        """
+        super().setUp()
+        self.kwargs = {
+            "request": Mock(),
+        }
+        self.pipeline = Mock()
+        self.hook_name = "openedx.service.context.location.type.vi"
+
+    @patch("openedx_filters.pipeline.get_pipeline_configuration")
+    @patch("openedx_filters.pipeline.get_functions_for_pipeline")
+    def test_run_empty_pipeline(self, get_functions_mock, get_configuration_mock):
+        """
+        This method runs an empty pipeline, i.e, a pipeline without
+        defined functions.
+
+        Expected behavior:
+            Returns the same input arguments.
+        """
+        get_configuration_mock.return_value = (
+            [],
+            True,
+        )
+        get_functions_mock.return_value = []
+
+        result = run_pipeline(self.hook_name, **self.kwargs)
+
+        get_configuration_mock.assert_called_once_with(
+            "openedx.service.context.location.type.vi",
+        )
+        get_functions_mock.assert_not_called()
+        self.assertDictEqual(result, self.kwargs)
+
+    @patch("openedx_filters.pipeline.get_pipeline_configuration")
+    @patch("openedx_filters.pipeline.get_functions_for_pipeline")
+    def test_raise_hook_exception(self, get_functions_mock, get_configuration_mock):
+        """
+        This method runs a pipeline with a function that raises
+        HookFilterException. This means that fail_silently must be set to
+        False.
+
+        Expected behavior:
+            The pipeline re-raises the exception caught.
+        """
+        get_configuration_mock.return_value = {
+            "pipeline": self.pipeline,
+            "fail_silently": False,
+        }
+        exception_message = "There was an error executing filter X."
+        function = Mock(side_effect=HookFilterException(message=exception_message))
+        function.__name__ = "function_name"
+        get_functions_mock.return_value = [function]
+        log_message = "Exception raised while running '{func_name}':\n HookFilterException: {exc_msg}".format(
+            func_name="function_name", exc_msg=exception_message,
+        )
+
+        with self.assertRaises(HookFilterException), self.assertLogs() as captured:
+            run_pipeline(self.hook_name, **self.kwargs)
+        self.assertEqual(
+            captured.records[0].getMessage(), log_message,
+        )
+
+    @patch("openedx_filters.pipeline.get_pipeline_configuration")
+    @patch("openedx_filters.pipeline.get_functions_for_pipeline")
+    def test_not_raise_hook_exception(self, get_functions_mock, get_hook_config_mock):
+        """
+        This method runs a pipeline with a function that raises
+        HookFilterException but raise_exception is set to False. This means
+        fail_silently must be set to True or not defined.
+
+        Expected behavior:
+            The pipeline does not re-raise the exception caught.
+        """
+        get_hook_config_mock.return_value = (
+            Mock(),
+            False,
+        )
+        return_value = {
+            "request": Mock(),
+        }
+        function_with_exception = Mock(side_effect=HookFilterException)
+        function_without_exception = Mock(return_value=return_value)
+        get_functions_mock.return_value = [
+            function_with_exception,
+            function_without_exception,
+        ]
+
+        result = run_pipeline(self.hook_name, **self.kwargs)
+
+        self.assertDictEqual(result, return_value)
+        function_without_exception.assert_called_once_with(**self.kwargs)
+
+    @patch("openedx_filters.pipeline.get_pipeline_configuration")
+    @patch("openedx_filters.pipeline.get_functions_for_pipeline")
+    def test_not_raise_common_exception(self, get_functions_mock, get_hook_config_mock):
+        """
+        This method runs a pipeline with a function that raises a
+        common Exception.
+
+        Expected behavior:
+            The pipeline continues execution after caughting Exception.
+        """
+        get_hook_config_mock.return_value = (
+            self.pipeline,
+            True,
+        )
+        return_value = {
+            "request": Mock(),
+        }
+        function_with_exception = Mock(side_effect=ValueError("Value error exception"))
+        function_with_exception.__name__ = "function_with_exception"
+        function_without_exception = Mock(return_value=return_value)
+        get_functions_mock.return_value = [
+            function_with_exception,
+            function_without_exception,
+        ]
+        log_message = (
+            "Exception raised while running 'function_with_exception': "
+            "Value error exception\nContinuing execution."
+        )
+
+        with self.assertLogs() as captured:
+            result = run_pipeline(self.hook_name, **self.kwargs)
+
+        self.assertEqual(
+            captured.records[0].getMessage(), log_message,
+        )
+        self.assertDictEqual(result, return_value)
+        function_without_exception.assert_called_once_with(**self.kwargs)
+
+    @patch("openedx_filters.pipeline.get_pipeline_configuration")
+    @patch("openedx_filters.pipeline.get_functions_for_pipeline")
+    def test_getting_pipeline_result(self, get_functions_mock, get_hook_config_mock):
+        """
+        This method runs a pipeline with functions defined via configuration.
+
+        Expected behavior:
+            Returns the processed dictionary.
+        """
+        get_hook_config_mock.return_value = (
+            self.pipeline,
+            True,
+        )
+        return_value_1st = {
+            "request": Mock(),
+        }
+        return_value_2nd = {
+            "user": Mock(),
+        }
+        return_overall_value = {**return_value_1st, **return_value_2nd}
+        first_function = Mock(return_value=return_value_1st)
+        second_function = Mock(return_value=return_value_2nd)
+        get_functions_mock.return_value = [
+            first_function,
+            second_function,
+        ]
+
+        result = run_pipeline(self.hook_name, **self.kwargs)
+
+        first_function.assert_called_once_with(**self.kwargs)
+        second_function.assert_called_once_with(**return_value_1st)
+        self.assertDictEqual(result, return_overall_value)
+
+    @patch("openedx_filters.pipeline.get_pipeline_configuration")
+    @patch("openedx_filters.pipeline.get_functions_for_pipeline")
+    def test_partial_pipeline(self, get_functions_mock, get_hook_config_mock):
+        """
+        This method runs a pipeline with functions defined via configuration.
+        At some point, returns an object to stop execution.
+
+        Expected behavior:
+            Returns the object used to stop execution.
+        """
+        get_hook_config_mock.return_value = (
+            self.pipeline,
+            True,
+        )
+        return_value_1st = Mock()
+        first_function = Mock(return_value=return_value_1st)
+        first_function.__name__ = "first_function"
+        second_function = Mock()
+        get_functions_mock.return_value = [
+            first_function,
+            second_function,
+        ]
+        log_message = "Pipeline stopped by 'first_function' for returning an object."
+
+        with self.assertLogs() as captured:
+            result = run_pipeline(self.hook_name, **self.kwargs)
+
+        self.assertEqual(
+            captured.records[0].getMessage(), log_message,
+        )
+        first_function.assert_called_once_with(**self.kwargs)
+        second_function.assert_not_called()
+        self.assertEqual(result, return_value_1st)

--- a/openedx_filters/tests/test_utils.py
+++ b/openedx_filters/tests/test_utils.py
@@ -1,0 +1,203 @@
+"""
+Tests for utilities used by the filters tooling.
+"""
+from unittest.mock import patch
+
+import ddt
+from django.test import TestCase, override_settings
+
+from ..utils import get_filter_config, get_functions_for_pipeline, get_pipeline_configuration
+
+
+def test_function():
+    """
+    Utility function used when getting functions for pipeline.
+    """
+
+
+@ddt.ddt
+class TestUtilityFunctions(TestCase):
+    """
+    Test class to verify standard behavior of utility functions.
+    """
+
+    def test_get_empty_function_list(self):
+        """
+        This method is used to verify the behavior of
+        get_functions_for_pipeline when an empty pipeline is
+        passed as argument.
+
+        Expected behavior:
+            Returns an empty list.
+        """
+        pipeline = []
+
+        function_list = get_functions_for_pipeline(pipeline)
+
+        self.assertEqual(function_list, pipeline)
+
+    def test_get_non_existing_function(self):
+        """
+        This method is used to verify the behavior of
+        get_functions_for_pipeline when a non-existing function
+        path is passed inside the pipeline argument.
+
+        Expected behavior:
+            Returns a list without the non-existing function.
+        """
+        pipeline = [
+            "openedx_filters.tests.test_utils.test_function",
+            "openedx_filters.tests.test_utils.non_existent",
+        ]
+        log_message = "Failed to import '{}'.".format(
+            "openedx_filters.tests.test_utils.non_existent"
+        )
+
+        with self.assertLogs() as captured:
+            function_list = get_functions_for_pipeline(pipeline)
+
+        self.assertEqual(
+            captured.records[0].getMessage(), log_message,
+        )
+        self.assertEqual(function_list, [test_function])
+
+    def test_get_non_existing_module_func(self):
+        """
+        This method is used to verify the behavior of
+        get_functions_for_pipeline when a non-existing module
+        path is passed inside the pipeline argument.
+
+        Expected behavior:
+            Returns a list without the non-existing function.
+        """
+        pipeline = [
+            "openedx_filters.tests.test_utils.test_function",
+            "openedx_filters.non_existent.test_utils.test_function",
+        ]
+        log_message = "Failed to import '{}'.".format(
+            "openedx_filters.non_existent.test_utils.test_function"
+        )
+
+        with self.assertLogs() as captured:
+            function_list = get_functions_for_pipeline(pipeline)
+
+        self.assertEqual(captured.records[0].getMessage(), log_message)
+        self.assertEqual(function_list, [test_function])
+
+    def test_get_function_list(self):
+        """
+        This method is used to verify the behavior of
+        get_functions_for_pipeline when a list of functions
+        paths is passed as the pipeline parameter.
+
+        Expected behavior:
+            Returns a list with the function objects.
+        """
+        pipeline = [
+            "openedx_filters.tests.test_utils.test_function",
+            "openedx_filters.tests.test_utils.test_function",
+        ]
+
+        function_list = get_functions_for_pipeline(pipeline)
+
+        self.assertEqual(function_list, [test_function] * 2)
+
+    def test_get_empty_hook_config(self):
+        """
+        This method is used to verify the behavior of
+        get_filter_config when a trigger without a
+        HOOKS_FILTER_CONFIG is passed as parameter.
+
+        Expected behavior:
+            Returns an empty dictionary.
+        """
+        result = get_filter_config("hook_name")
+
+        self.assertEqual(result, {})
+
+    @override_settings(
+        HOOK_FILTERS_CONFIG={
+            "openedx.service.context.location.type.vi": {
+                "pipeline": [
+                    "openedx_filters.tests.test_utils.test_function",
+                    "openedx_filters.tests.test_utils.test_function",
+                ],
+                "fail_silently": False,
+            }
+        }
+    )
+    def test_get_hook_config(self):
+        """
+        This method is used to verify the behavior of
+        get_filter_config when a trigger with
+        HOOKS_FILTER_CONFIG defined is passed as parameter.
+
+        Expected behavior:
+            Returns a tuple with pipeline configurations.
+        """
+        expected_result = {
+            "pipeline": [
+                "openedx_filters.tests.test_utils.test_function",
+                "openedx_filters.tests.test_utils.test_function",
+            ],
+            "fail_silently": False,
+        }
+
+        result = get_filter_config("openedx.service.context.location.type.vi")
+
+        self.assertDictEqual(result, expected_result)
+
+    @patch("openedx_filters.utils.get_filter_config")
+    @ddt.data(
+        (("openedx_filters.tests.test_utils.test_function",), ([], False,)),
+        ({}, ([], False,)),
+        (
+            {
+                "pipeline": [
+                    "openedx_filters.tests.test_utils.test_function",
+                    "openedx_filters.tests.test_utils.test_function",
+                ],
+                "fail_silently": False,
+            },
+            (
+                [
+                    "openedx_filters.tests.test_utils.test_function",
+                    "openedx_filters.tests.test_utils.test_function",
+                ],
+                True,
+            ),
+        ),
+        (
+            [
+                "openedx_filters.tests.test_utils.test_function",
+                "openedx_filters.tests.test_utils.test_function",
+            ],
+            (
+                [
+                    "openedx_filters.tests.test_utils.test_function",
+                    "openedx_filters.tests.test_utils.test_function",
+                ],
+                False,
+            ),
+        ),
+        (
+            "openedx_filters.tests.test_utils.test_function",
+            (["openedx_filters.tests.test_utils.test_function", ], False,),
+        ),
+    )
+    @ddt.unpack
+    def test_get_pipeline_config(self, config, expected_result, get_filter_config_mock):
+        """
+        This method is used to verify the behavior of
+        get_pipeline_configuration when a trigger with
+        HOOKS_FILTER_CONFIG defined is passed as parameter.
+
+        Expected behavior:
+            Returns a tuple with the pipeline and exception handling
+            configuration.
+        """
+        get_filter_config_mock.return_value = config
+
+        result = get_pipeline_configuration("hook_name")
+
+        self.assertTupleEqual(result, expected_result)

--- a/openedx_filters/utils.py
+++ b/openedx_filters/utils.py
@@ -1,0 +1,139 @@
+"""
+Utilities for the hooks module.
+"""
+from logging import getLogger
+
+from django.conf import settings
+from django.utils.module_loading import import_string
+
+log = getLogger(__name__)
+
+
+def get_functions_for_pipeline(pipeline):
+    """
+    Get function objects from paths.
+
+    Helper function that given a pipeline with functions paths gets
+    the objects related to each path.
+
+    Example usage:
+        functions = get_functions_for_pipeline(
+            [
+                '1st_path_to_function',
+                ...
+            ]
+        )
+        >>> functions
+        [
+            <function 1st_function at 0x00000000000>,
+            <function 2nd_function at 0x00000000001>,
+            ...
+        ]
+
+    Arguments:
+        pipeline (list): paths where functions are defined.
+
+    Returns:
+        function_list (list): function objects defined in pipeline.
+    """
+    function_list = []
+    for function_path in pipeline:
+        try:
+            function = import_string(function_path)
+            function_list.append(function)
+        except ImportError:
+            log.exception("Failed to import '%s'.", function_path)
+
+    return function_list
+
+
+def get_pipeline_configuration(hook_name):
+    """
+    Get pipeline configuration from filter settings.
+
+    Helper function used to get the configuration needed to execute
+    the Pipeline Runner. It will take from the hooks configuration
+    the list of functions to execute and how to execute them.
+
+    Example usage:
+        pipeline_config = get_pipeline_configuration('trigger')
+        >>> pipeline_config
+            (
+                [
+                    'my_plugin.hooks.filters.test_function',
+                    'my_plugin.hooks.filters.test_function_2nd',
+                ],
+            )
+
+    Arguments:
+        hook_name (str): determines which is the trigger of this
+        pipeline.
+
+    Returns:
+        pipeline (list): paths where functions for the pipeline are
+        defined.
+        raise_exception (bool): defines whether exceptions are raised while
+        executing the pipeline associated with a filter. It's determined by
+        fail_silently configuration, True meaning it won't raise exceptions and
+        False the opposite.
+    """
+    hook_config = get_filter_config(hook_name)
+
+    if not hook_config:
+        return [], False
+
+    pipeline, raise_exception = [], False
+
+    if isinstance(hook_config, dict):
+        pipeline, raise_exception = (
+            hook_config.get("pipeline", []),
+            not hook_config.get("fail_silently", True),
+        )
+
+    elif isinstance(hook_config, list):
+        pipeline = hook_config
+
+    elif isinstance(hook_config, str):
+        pipeline.append(hook_config)
+
+    return pipeline, raise_exception
+
+
+def get_filter_config(hook_name):
+    """
+    Get filters configuration from settings.
+
+    Helper function used to get configuration needed for using
+    Hooks Extension Framework.
+
+    Example usage:
+            configuration = get_filter_config('trigger')
+            >>> configuration
+            {
+                'pipeline':
+                    [
+                        'my_plugin.hooks.filters.test_function',
+                        'my_plugin.hooks.filters.test_function_2nd',
+                    ],
+                'fail_silently': False,
+            }
+
+            Where:
+                - pipeline (list): paths where the functions to be executed by
+                the pipeline are defined.
+                - fail_silently (bool): determines whether the pipeline can
+                raise exceptions while executing. If its value is True then
+                exceptions (HookFilterException) are caught and the execution
+                continues, if False then exceptions are re-raised and the
+                execution fails.
+
+    Arguments:
+        hook_name (str): determines which configuration to use.
+
+    Returns:
+        hooks configuration (dict): taken from Django settings
+        containing hooks configuration.
+    """
+    hooks_config = getattr(settings, "HOOK_FILTERS_CONFIG", {})
+
+    return hooks_config.get(hook_name, {})

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -42,5 +42,5 @@ tox==3.23.0
     # via -r requirements/ci.in
 urllib3==1.26.4
     # via requests
-virtualenv==20.4.3
+virtualenv==20.4.4
     # via tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -12,7 +12,7 @@ asgiref==3.3.4
     # via
     #   -r requirements/quality.txt
     #   django
-astroid==2.5.2
+astroid==2.5.3
     # via
     #   -r requirements/quality.txt
     #   pylint
@@ -72,6 +72,8 @@ cryptography==3.4.7
     # via
     #   -r requirements/quality.txt
     #   secretstorage
+ddt==1.4.2
+    # via -r requirements/quality.txt
 diff-cover==5.0.1
     # via -r requirements/dev.in
 distlib==0.3.1
@@ -83,7 +85,7 @@ django==3.2
     #   -r requirements/quality.txt
     #   code-annotations
     #   edx-lint
-docutils==0.17
+docutils==0.17.1
     # via
     #   -r requirements/quality.txt
     #   readme-renderer
@@ -99,7 +101,7 @@ idna==2.10
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   requests
-importlib-metadata==3.10.0
+importlib-metadata==4.0.1
     # via
     #   -r requirements/quality.txt
     #   keyring
@@ -158,7 +160,7 @@ pep517==0.10.0
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools
-pip-tools==6.0.1
+pip-tools==6.1.0
     # via -r requirements/pip-tools.txt
 pkginfo==1.7.0
     # via
@@ -194,7 +196,7 @@ pylint-celery==0.3
     # via
     #   -r requirements/quality.txt
     #   edx-lint
-pylint-django==2.4.2
+pylint-django==2.4.3
     # via
     #   -r requirements/quality.txt
     #   edx-lint
@@ -217,7 +219,7 @@ pyparsing==2.4.7
     #   packaging
 pytest-cov==2.11.1
     # via -r requirements/quality.txt
-pytest-django==4.1.0
+pytest-django==4.2.0
     # via -r requirements/quality.txt
 pytest==6.2.3
     # via
@@ -310,7 +312,7 @@ urllib3==1.26.4
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   requests
-virtualenv==20.4.3
+virtualenv==20.4.4
     # via
     #   -r requirements/ci.txt
     #   tox

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -34,13 +34,15 @@ coverage==5.5
     # via
     #   -r requirements/test.txt
     #   pytest-cov
+ddt==1.4.2
+    # via -r requirements/test.txt
 django==3.2
     # via
     #   -r requirements/test.txt
     #   code-annotations
 doc8==0.8.1
     # via -r requirements/doc.in
-docutils==0.17
+docutils==0.16
     # via
     #   doc8
     #   readme-renderer
@@ -94,7 +96,7 @@ pyparsing==2.4.7
     #   packaging
 pytest-cov==2.11.1
     # via -r requirements/test.txt
-pytest-django==4.1.0
+pytest-django==4.2.0
     # via -r requirements/test.txt
 pytest==6.2.3
     # via
@@ -128,7 +130,7 @@ six==1.15.0
     #   readme-renderer
 snowballstemmer==2.1.0
     # via sphinx
-sphinx==3.5.3
+sphinx==3.5.4
     # via
     #   -r requirements/doc.in
     #   edx-sphinx-theme

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -8,7 +8,7 @@ click==7.1.2
     # via pip-tools
 pep517==0.10.0
     # via pip-tools
-pip-tools==6.0.1
+pip-tools==6.1.0
     # via -r requirements/pip-tools.in
 toml==0.10.2
     # via pep517

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -10,5 +10,5 @@ wheel==0.36.2
 # The following packages are considered to be unsafe in a requirements file:
 pip==21.0.1
     # via -r requirements/pip.in
-setuptools==54.2.0
+setuptools==56.0.0
     # via -r requirements/pip.in

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -8,7 +8,7 @@ asgiref==3.3.4
     # via
     #   -r requirements/test.txt
     #   django
-astroid==2.5.2
+astroid==2.5.3
     # via
     #   pylint
     #   pylint-celery
@@ -44,18 +44,20 @@ coverage==5.5
     #   pytest-cov
 cryptography==3.4.7
     # via secretstorage
+ddt==1.4.2
+    # via -r requirements/test.txt
 django==3.2
     # via
     #   -r requirements/test.txt
     #   code-annotations
     #   edx-lint
-docutils==0.17
+docutils==0.17.1
     # via readme-renderer
 edx-lint==5.0.0
     # via -r requirements/quality.in
 idna==2.10
     # via requests
-importlib-metadata==3.10.0
+importlib-metadata==4.0.1
     # via
     #   keyring
     #   twine
@@ -114,7 +116,7 @@ pygments==2.8.1
     # via readme-renderer
 pylint-celery==0.3
     # via edx-lint
-pylint-django==2.4.2
+pylint-django==2.4.3
     # via edx-lint
 pylint-plugin-utils==0.6
     # via
@@ -132,7 +134,7 @@ pyparsing==2.4.7
     #   packaging
 pytest-cov==2.11.1
     # via -r requirements/test.txt
-pytest-django==4.1.0
+pytest-django==4.2.0
     # via -r requirements/test.txt
 pytest==6.2.3
     # via

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -3,6 +3,7 @@
 
 -r base.txt               # Core dependencies for this package
 
+ddt                       # A library to multiply test cases
 pytest-cov                # pytest extension for code coverage statistics
 pytest-django             # pytest extension for better Django support
 code-annotations          # provides commands used by the pii_check make target.

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -16,6 +16,8 @@ code-annotations==1.1.1
     # via -r requirements/test.in
 coverage==5.5
     # via pytest-cov
+ddt==1.4.2
+    # via -r requirements/test.in
 django==3.2
     # via
     #   -r requirements/base.txt
@@ -38,7 +40,7 @@ pyparsing==2.4.7
     # via packaging
 pytest-cov==2.11.1
     # via -r requirements/test.in
-pytest-django==4.1.0
+pytest-django==4.2.0
     # via -r requirements/test.in
 pytest==6.2.3
     # via


### PR DESCRIPTION
**Description:** 

This PR adds the tooling needed by the Hooks Extension Framework to execute filters. This project is described in more depth in the [OEP-50](https://github.com/edx/open-edx-proposals/pull/184).  

The tooling consists of a pipeline ([Pipeline tooling ADR](https://github.com/eduNEXT/openedx-filters/blob/ef4e5e093fb753539cd16729bc8f924ba964e7a5/docs/decisions/0003-hooks-filter-tooling-pipeline.rst)) that executes a list of functions pre-configured that are associated with the filter via Django settings ([Filters configuration ADR](https://github.com/eduNEXT/openedx-filters/blob/ef4e5e093fb753539cd16729bc8f924ba964e7a5/docs/decisions/0002-hooks-filter-config-location.rst)).

**Dependencies:** 
The architectural design records where the configuration and pipeline design used by the tooling are defined in Pull Request #2. 

**Testing instructions:**

1. Run `make lms-shell`
2. Inside the shell run: 
    `pip install -e git+https://github.com/eduNEXT/openedx-filters.git@MJG/filter_tooling#egg=filter_tooling`
3. Run `pip install -e https://github.com/eduNEXT/openedx-basic-hooks.git`, you can also use your own test library. Here are defined the functions that will be executed by a trigger. 
4. [Here's](https://github.com/eduNEXT/edx-platform/pull/212/files) a quick and dirty way to create and use filters on edx-platform. In the example we are using pre_register_filter that's soon to be added (PR pending).
5. (Optional) If you're using our demo and sample openedx-base-hooks, you can use our pre_register_filter. What you'll have to do is execute the logic that the filter extended, for example: 
- Go to register
- Enter data for registration and in the field `Year of birth` add 2020 (or any year after 2000).
- Then, an error will be displayed caused by the HookFilterException raised by our filter function defined in [this  location](https://github.com/eduNEXT/edx-platform/blob/06e45eb856574d3757e44ca8513afe78ef351079/openedx/core/djangoapps/user_authn/views/register.py#L531)

**Reviewers:**
- [ ] @morenol 
- [ ] @felipemontoya 

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)
