### PR TITLE
docs: add ADRs for filter tooling and configuration

### DIFF
--- a/docs/decisions/0001-purpose-of-this-repo.rst
+++ b/docs/decisions/0001-purpose-of-this-repo.rst
@@ -4,26 +4,32 @@
 Status
 ------
 
-Draft
+Accepted
+
 
 Context
 -------
 
-TODO: Give context on what lead to the creation of this repo.
-      What project is the repo related to?
+OEP-50 (Hooks Extension Framework) was written with the intention of defining a
+common pattern to extend the platform in a number of locations in a very stable
+way. After receiving feedback from different community members and edx arch
+team, it was decided that the best path forward would be to create a repository
+that holds the signature of the public promise made by the framework.
+
 
 Decision
 --------
 
-TODO: Clearly state how the context above led you to creating this repo.
+In this repository will reside the functions that define the filter used by the
+edx-platform repo. The same applies to the necessary tooling used by the Hooks
+Extension Framework to manage the filter pipelines and extra tools.
+
 
 Consequences
 ------------
 
-TODO: As a result of this repo's creation, what other things will change.
-
-Rejected Alternatives
----------------------
-
-TODO: If applicable, list viable alternatives to creating this new repo and
- give reasons for why they were rejected.
+All tools needed to manage filters will be implemented in this repository and
+imported into Open edX platform.
+Developers that want to extend to use filters on the defined hooks should also
+import this repository as a dependency in their Open edX plugins and use the
+same function definitions.

--- a/docs/decisions/0002-hooks-filter-config-location.rst
+++ b/docs/decisions/0002-hooks-filter-config-location.rst
@@ -1,0 +1,112 @@
+Configuration for filters in the Hooks Extension Framework
+==========================================================
+
+Status
+------
+
+Accepted
+
+
+Context
+-------
+
+Context taken from the Discuss thread `Configuration for the Hooks Extension Framework <https://discuss.openedx.org/t/configuration-for-the-hooks-extension-framework/4527>`_
+
+We need a way to configure a list of functions (filters) that will be called at
+different places (hooks) in the code of edx-platform.
+
+So, for a string like:
+
+"org.openedx.lms.auth_user.filter.before_creation.v1"
+
+We need to define a list of functions:
+
+.. code-block:: python
+
+    [
+        "from_a_plugin.filters.filter_1",
+        "from_a_plugin.filters.filter_n",
+        "from_some_other_package.filters.filter_1",
+        # ... and so.
+    ]
+
+
+We have considered two alternatives:
+
+* A dict in the Django settings.
+    * Advantages:
+        * It is very standard, everyone should know how to change it by now.
+        * Can be altered without installing plugins.
+    * Disadvantages:
+        * It is hard to document a large dict.
+        * Could grow into something difficult to manage.
+
+* In a view of the AppConfig of your plugin.
+    * Advantages:
+        * Each plugin can extend the config to add its own filters without
+          collisions.
+    * Disadvantages:
+        * It’s not possible to control the ordering of different filters being
+          connected to the same trigger by different plugins.
+        * For updates, an operator must install a new version of the dependency
+          which usually is longer and more difficult than changing vars and
+          restart.
+        * Not easy to configure by tenant if you use site configs.
+        * Requires a plugin.
+
+Decision
+--------
+
+We decided to use a dictionary in Django settings using one of these three
+formats:
+
+**Option 1**: this is the more detailed option and from it, the others can be
+derived. This configuration is very explicit. It contains the list of functions
+for the pipeline and any other optional setting for a filter.
+
+
+.. code-block:: python
+
+    HOOK_FILTERS_CONFIG = {
+        "org.openedx.lms.auth_user.filter.before_creation.v1": {
+            "pipeline": [
+                "from_a_plugin.filters.filter_1",
+                "from_a_plugin.filters.filter_n",
+                "from_some_other_package.filters.filter_1",
+            ],
+            "other_options": "go here",
+        }
+    }
+
+**Option 2**: this option only considers the configuration of the list of
+functions to be run by the pipeline.
+
+.. code-block:: python
+
+    HOOK_FILTERS_CONFIG = {
+        "org.openedx.lms.auth_user.filter.before_creation.v1": {
+            [
+                "from_a_plugin.filters.filter_1",
+                "from_a_plugin.filters.filter_n",
+                "from_some_other_package.filters.filter_1",
+            ],
+        }
+    }
+
+**Option 3**: this option considers that there's just one function to be run.
+
+.. code-block:: python
+
+    HOOK_FILTERS_CONFIG = {
+        "org.openedx.lms.auth_user.filter.before_creation.v1": "from_a_plugin.filters.filter_1",
+    }
+
+
+Consequences
+------------
+
+1. Open edX plugins will need to use the settings entry point to add a function
+to a filter hook.
+
+2. Given that Site Configurations is not available in this repository, it can't
+be used to configure hooks.

--- a/docs/decisions/0003-hooks-filter-tooling-pipeline.rst
+++ b/docs/decisions/0003-hooks-filter-tooling-pipeline.rst
@@ -1,0 +1,57 @@
+Hooks tooling: pipeline for filters
+===================================
+
+Status
+------
+
+Accepted
+
+
+Context
+-------
+
+Taking into account the design considerations outlined in OEP-50 Hooks extension
+framework about
+
+1. The order of execution for multiple functions in a filter must be respected
+2. The result of a previous function must be available to the current one in the
+   form of a pipeline
+
+
+See https://github.com/edx/open-edx-proposals/pull/184 for more information.
+
+To do this, we considered three similar approaches for the pipeline implementation:
+
+1. Unix-like (how unix pipe operator works): the output of the previous function
+   is the input of the next one. For the first function, includes the initial
+   arguments.
+2. Unix-like modified: the output of the previous function is the input of the
+   next one including the initial arguments for all functions.
+3. Accumulative: the output of every (i, …, i-n) function is accumulated using a
+   data structure and fed into the next function i-n+1, including the initial
+   arguments. We draw inspiration from python-social-auth/social-core.
+   See: https://github.com/python-social-auth/social-core
+
+These approaches follow the pipeline pattern and have as main difference what
+each function receive as input.
+
+It is important to emphasize that the main objectives with this implementation
+are: to have function interchangeability and to maintain the function signature
+of a filter defined by the Hooks Extension Framework.
+
+
+Decision
+--------
+
+We decided to use the accumulative approach as the only pipeline for filters.
+
+
+Consequences
+------------
+
+1. The order of execution is maintained.
+2. Given that all pipeline functions will expect the same input arguments,
+   i.e accumulated output plus initial arguments, their signature will stay the
+   same. And for this reason, these functions are interchangeable.
+3. To avoid any mismatch filters must have \*args and \*\*kwargs in their
+   function definition.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,7 +4,7 @@
    contain the root `toctree` directive.
 
 openedx-filters
-==============
+===============
 
 What is this project?
 


### PR DESCRIPTION
**Description:** 

This PRs adds Architectural Decision Records (ADR) for filters on the following subjects:

- Purpose of openedx-filters
- Tooling: how to execute filters
- Configuration: how to configure filters

**JIRA:** Link to JIRA ticket

**Dependencies:** dependencies on other outstanding PRs, issues, etc. 

**Merge deadline:** List merge deadline (if any)

**Installation instructions:** List any non-trivial installation 
instructions.

**Testing instructions:**
This PR just adds documentation. 

**Reviewers:**
- [x] @morenol 
- [x] @felipemontoya  

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)
