### PR TITLE
test: add missing configuration for testing

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,7 +4,7 @@
    contain the root `toctree` directive.
 
 openedx-filters
-==============
+===============
 
 What is this project?
 

--- a/manage.py
+++ b/manage.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+"""
+Django administration utility.
+"""
+
+import os
+import sys
+
+PWD = os.path.abspath(os.path.dirname(__file__))
+
+if __name__ == '__main__':
+    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'test_utils.test_settings')
+    sys.path.append(PWD)
+    try:
+        from django.core.management import execute_from_command_line
+    except ImportError:
+        # The above import may fail for some other reason. Ensure that the
+        # issue is really that Django is missing to avoid masking other
+        # exceptions on Python 2.
+        try:
+            import django  # pylint: disable=unused-import
+        except ImportError as error:
+            raise ImportError(
+                "Couldn't import Django. Are you sure it's installed and "
+                "available on your PYTHONPATH environment variable? Did you "
+                "forget to activate a virtual environment?"
+            ) from error
+        raise
+    execute_from_command_line(sys.argv)

--- a/test_utils/test_settings.py
+++ b/test_utils/test_settings.py
@@ -1,0 +1,31 @@
+
+"""
+These settings are here to use during tests, because django requires them.
+
+In a real-world use case, apps in this project are installed into other
+Django applications, so these settings will not be used.
+"""
+
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": "default.db",
+        "USER": "",
+        "PASSWORD": "",
+        "HOST": "",
+        "PORT": "",
+    },
+    "read_replica": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": "read_replica.db",
+        "USER": "",
+        "PASSWORD": "",
+        "HOST": "",
+        "PORT": "",
+    },
+}
+
+
+INSTALLED_APPS = (
+    "openedx_filters",
+)

--- a/tests/test_openedx_filters.py
+++ b/tests/test_openedx_filters.py
@@ -1,3 +1,4 @@
+
 """
 Tests for openedx_filters.py.
 """

--- a/tox.ini
+++ b/tox.ini
@@ -32,6 +32,7 @@ ignore = D101,D200,D203,D212,D215,D404,D405,D406,D407,D408,D409,D410,D411,D412,D
 
 
 [pytest]
+DJANGO_SETTINGS_MODULE = test_utils.test_settings
 addopts = --cov openedx_filters --cov-report term-missing --cov-report xml
 norecursedirs = .* docs requirements site-packages
 
@@ -43,6 +44,7 @@ commands =
 
 [testenv:docs]
 setenv =
+    DJANGO_SETTINGS_MODULE = test_utils.test_settings
     PYTHONPATH = {toxinidir}
 whitelist_externals =
     make
@@ -69,7 +71,7 @@ commands =
 
 [testenv:pii_check]
 setenv =
-    DJANGO_SETTINGS_MODULE = test_settings
+    DJANGO_SETTINGS_MODULE = test_utils.test_settings
 deps =
     -r{toxinidir}/requirements/test.txt
 commands =


### PR DESCRIPTION
**Description:** 

This PR adds the necessary configuration to run unittesting using django settings.

**Testing instructions:**

1. PR #1 uses this configuration to run tests

**Reviewers:**
- [ ] @felipemontoya 
- [x] @morenol 

