### PR TITLE
docs: ADR for Open edX filters naming

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,7 @@ Changed
 _______
 
 * Update doc-max-length following community recommendations.
+* Add ADRs for naming, payload and debugging tools.
 
 [0.2.0] - 2021-09-02
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/decisions/0003-hooks-filter-tooling-pipeline.rst
+++ b/docs/decisions/0003-hooks-filter-tooling-pipeline.rst
@@ -1,5 +1,5 @@
-Hooks tooling: pipeline for filters
-===================================
+Filter tooling: pipeline behaviour
+==================================
 
 Status
 ------

--- a/docs/decisions/0004-filters-naming-and-versioning.rst
+++ b/docs/decisions/0004-filters-naming-and-versioning.rst
@@ -1,0 +1,119 @@
+Open edX filters naming and versioning
+======================================
+
+Status
+------
+
+Draft
+
+
+Context
+-------
+
+Filter-type hooks are an important public promise. They are a strong foundation
+of a healthy ecosystem of extensions for the Open edX world and have been
+recognized as such by the arch team of the Open edX core and also by the community.
+
+This ADR has the purpose of defining the rules to be followed when naming an
+Open edX Filter with the intent of covering the use cases of:
+
+* Open edX core developers wanting to add new filters.
+* Open edX core developers wanting to deprecate and eventually remove filters.
+* Open edX core developers wanting to add additional information to an existing
+  filters in a mostly backward compatible way.
+* Open edX extension developers wanting to have as few restrictions as reasonable
+  on the extension capabilities at the filter location.
+* Open edX extension developers wanting to create and maintain stable
+  applications, even when the filters framework evolves and changes over time.
+
+Evolving stably and creating few restrictions on the filters are two use cases
+at odds with each other, and this ADR and overall framework tries to
+find a good balance between them.
+
+
+Decisions
+---------
+
+1. The name of a filter will be a ``string`` that follows the `type format`_
+defined in the `OEP-41`_:
+
+``{Reverse DNS}.{Architecture Subdomain}.{Subject}.{Action}.{Major Version}``
+
+Rationale: Although filters are geared more towards edx-platform and will not
+be sent via a message bus, we still find that having a consistent naming scheme
+is very important.
+
+Examples:
+
+* org.openedx.learning.course.enrollment.creation.requested.v1
+* org.openedx.learning.student.registration.requested.v2
+* org.openedx.learning.session.login.requested.v1
+* org.openedx.learning.certificate.render.started.v1
+
+
+2. This name will be used as part of the configuration of every filter,
+for example:
+
+.. code-block:: python
+
+    OPEN_EDX_FILTERS_CONFIG = {
+        "org.openedx.learning.course.enrollment.creation.requested.v1": {
+            "pipeline": [
+                "first_plugin.module.check_enrollment_if_enterprise",
+                "second_plugin.module.check_crm_data_for_enrollment",
+            ],
+        }
+    }
+
+
+3. The filter definitions will be placed written in code in a way that is more
+practical and familiar for python developers with an emphasis on Django experience.
+The definition will be grouped by subdomain along with other data structures in a
+way that favors reuse.
+Only the `Architecture Subdomain`_ part of the filter name will be used in the
+package name of the filter definition.
+What constitutes a filter is that is a class that inherits from the main
+OpenEdxPublicFilter, which implements all the inner workings of the framework.
+
+
+4. The filters library will use SemVer 2. The major version will not be tied to
+Open edX releases for the time being. We still recognize that Open edX releases
+are the logical boundary to remove filters and make breaking changes
+such as eliminating filter definitions.
+
+
+5. Each filter will have a major and minor version only. The major version will
+be part of the `filter name` and be written to the classname defining
+the filter. However, version 1 (V1) of a filter will remove the _V1 suffix for
+readability. We also expect to have relatively few breaking changes to the
+filter definitions. The minor version of a filter will be written in the payload
+passed to the implementing function so that extension developers can react to it
+if they so desire.
+
+
+6. The filters library will be a single library containing the filter
+definitions, the necessary classes, and the tools to support the filters
+framework. These definitions will be written with a logical boundary such that if
+the project ever decides to separate them in a split library, there is no
+necessary large refactor.
+
+.. _type format: https://open-edx-proposals.readthedocs.io/en/latest/oep-0041-arch-async-server-event-messaging.html#id5
+.. _Architecture Subdomain: https://openedx.atlassian.net/wiki/spaces/AC/pages/663224968/edX+DDD+Bounded+Contexts
+.. _OEP-41: https://open-edx-proposals.readthedocs.io/en/latest/oep-0041-arch-async-server-event-messaging.html#specification
+
+Consequences
+------------
+
+1. There will not be a necessary correspondence between Open edX releases and
+major versions of this library. Also, there will not be a need to make a major
+release if there is no breaking for consecutive Open edX releases.
+
+2. Open edX core, and in particular, edx-platform must run the filters meant for
+public consumption as they are written in this library, changes in edx-platform
+that require changes in the public filter will require a backward compatible
+addition to this library or an altogether new filter with support for the old
+filter until deprecated and removed.
+
+3. Changing the arguments passed to a filter must always be done in a backward
+compatible way since making it incompatible warrants the use of a new major
+version.

--- a/docs/decisions/0005-filters-payload.rst
+++ b/docs/decisions/0005-filters-payload.rst
@@ -1,0 +1,60 @@
+Open edX filters payload conventions
+====================================
+
+Status
+------
+
+Draft
+
+
+Context
+-------
+
+Although filters have a public promise status, and thus maintainability is an
+important design goal, filters by definition permit that extension developers
+manipulate data that will be passed along to the lms or cms processes.
+
+At the same time, using fixed attr classes such as what is used in events is not
+convenient when trying to have few restrictions on what developers can do.
+
+That said, things should still be allowed to evolve in a backward compatible
+manner. When things inevitably break, we would like them to break in CI.
+Which just as in the case of Open edX Events, should not require the code of
+edx-platform to test integrations.
+
+
+Decisions
+---------
+
+1. Filters will receive metadata information about the filter, e.g, its minor version.
+
+2. Filter specific data will be passed to the implementing function unpacked as
+keyword arguments, so that mismatch errors are caught in CI.
+
+3. The metadata information will be calculated on the fly by the
+`OpenEdxPublicFilters` class to keep this information out of the way when writing
+the filter definition and calling location.
+
+4. The data sent to a filter will use in-memory objects in a way that is more
+practical and familiar for python developers with Django and Open edX specific
+experience.
+
+.. _OEP-41 format: https://open-edx-proposals.readthedocs.io/en/latest/oep-0041-arch-async-server-event-messaging.html#message-format
+
+
+Consequences
+------------
+
+1. During testing I can as a developer mock the edx-platform objects passed to
+   my filter and run thorough tests without ever requiring the edx-platform code.
+
+2. Extension developer will be able to manipulate Django or otherwise edx-platform
+   objects, which increases the risk of extensions breaking when the platform changes.
+
+3. CI testing will not be able to catch all runtime errors.
+
+4. Catching and debugging errors when testing on a runtime environment that does
+   use the edx-platform code is critical.
+
+5. Extension developers will be able to react to different versions of a filter
+   simultaneously if the read the envelope information.

--- a/docs/decisions/0006-filter-debug-tooling.rst
+++ b/docs/decisions/0006-filter-debug-tooling.rst
@@ -1,0 +1,41 @@
+Filter tooling: debugging tools
+===============================
+
+Status
+------
+
+Draft
+
+
+Context
+-------
+
+By accessing in-memory models and other objects, filters have a large
+surface area for breaking. To minimize this, it is necessary that the filter
+framework allows for good monitoring, logging, and debugging capabilities.
+
+Measuring performance is best accomplished by having persisted data that can be
+used for statistical analysis.
+
+
+Decisions
+---------
+
+1. Tooling for debugging must be able to be turned on/off per filter and in
+straightforward way in the same way that filters are normally configured.
+
+2. Logging tools for the pipeline execution must allow that a developer logs
+both a filter function individually at its step and together with other
+functions called before or after in the same pipeline run.
+
+3. It should be possible to send performance data to external services such as
+sentry or newrelic.
+
+
+Consequences
+------------
+
+1. The `OpenEdxPublicFilters` class must implement different logging strategies.
+
+2. There will possibly be a dependency on some third-party tools for data
+aggregation.


### PR DESCRIPTION
**Description:**

This PR adds an Architectural Design Record for:

- Filters naming and versioning
- Filters payloads
- Debugging tools

Discuss [thread](https://discuss.openedx.org/t/hooks-framework-filters/5753) that goes along this conversation.

**Author concerns:** 
- [ ] Should we send the metadata inspired on OEP-41?
- [ ] Do we pass objects as they are or do we map to attr classes?