### PR TITLE
refactor: change base exception name to OpenEdxFilterException

### DIFF
--- a/openedx_filters/exceptions.py
+++ b/openedx_filters/exceptions.py
@@ -3,7 +3,7 @@ Exceptions thrown by filters.
 """
 
 
-class HookFilterException(Exception):
+class OpenEdxFilterException(Exception):
     """
     Base exception for filters.
 
@@ -20,7 +20,7 @@ class HookFilterException(Exception):
 
     def __init__(self, message="", redirect_to=None, status_code=None, **kwargs):
         """
-        Init method for HookFilterException.
+        Init method for OpenEdxFilterException.
 
         It's designed to allow flexible instantiation through **kwargs.
         """
@@ -33,6 +33,6 @@ class HookFilterException(Exception):
 
     def __str__(self):
         """
-        Show string representation of HookFilterException using its message.
+        Show string representation of OpenEdxFilterException using its message.
         """
-        return "HookFilterException: {}".format(self.message)
+        return "OpenEdxFilterException: {}".format(self.message)

--- a/openedx_filters/pipeline.py
+++ b/openedx_filters/pipeline.py
@@ -3,7 +3,7 @@ Pipeline runner used to execute list of functions (filters).
 """
 from logging import getLogger
 
-from openedx_filters.exceptions import HookFilterException
+from openedx_filters.exceptions import OpenEdxFilterException
 from openedx_filters.utils import get_functions_for_pipeline, get_pipeline_configuration
 
 log = getLogger(__name__)
@@ -41,7 +41,7 @@ def run_pipeline(filter_name, *args, **kwargs):
         an object different than Dict or None.
 
     Exceptions raised:
-        HookFilterException: custom exception re-raised when a function raises
+        OpenEdxFilterException: custom exception re-raised when a function raises
         an exception of this type and raise_exception is set to True. This
         behavior is common when using filters.
 
@@ -67,7 +67,7 @@ def run_pipeline(filter_name, *args, **kwargs):
                 )
                 return result
             out.update(result)
-        except HookFilterException as exc:
+        except OpenEdxFilterException as exc:
             if raise_exception:
                 log.exception(
                     "Exception raised while running '%s':\n %s", function.__name__, exc,

--- a/openedx_filters/tests/test_exceptions.py
+++ b/openedx_filters/tests/test_exceptions.py
@@ -3,23 +3,23 @@ Tests for custom Hooks Exceptions.
 """
 from django.test import TestCase
 
-from openedx_filters.exceptions import HookFilterException
+from openedx_filters.exceptions import OpenEdxFilterException
 
 
-class TestCustomHookFilterException(TestCase):
+class TestCustomOpenEdxFilterException(TestCase):
     """
-    Test class used to check flexibility when using  HookFilterException.
+    Test class used to check flexibility when using  OpenEdxFilterException.
     """
 
     def test_exception_extra_arguments(self):
         """
-        This method raises HookFilterException with custom dynamic arguments.
+        This method raises OpenEdxFilterException with custom dynamic arguments.
 
         Expected behavior:
             Custom parameters can be accessed as instance arguments.
         """
-        hook_exception = HookFilterException(custom_arg="custom_argument")
+        filter_exception = OpenEdxFilterException(custom_arg="custom_argument")
 
         self.assertEqual(
-            hook_exception.custom_arg, "custom_argument",  # pylint: disable=no-member
+            filter_exception.custom_arg, "custom_argument",  # pylint: disable=no-member
         )

--- a/openedx_filters/tests/test_pipeline.py
+++ b/openedx_filters/tests/test_pipeline.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock, patch
 
 from django.test import TestCase
 
-from openedx_filters.exceptions import HookFilterException
+from openedx_filters.exceptions import OpenEdxFilterException
 from openedx_filters.pipeline import run_pipeline
 
 
@@ -51,10 +51,10 @@ class TestRunningPipeline(TestCase):
 
     @patch("openedx_filters.pipeline.get_pipeline_configuration")
     @patch("openedx_filters.pipeline.get_functions_for_pipeline")
-    def test_raise_hook_exception(self, get_functions_mock, get_configuration_mock):
+    def test_raise_filter_exception(self, get_functions_mock, get_configuration_mock):
         """
         This method runs a pipeline with a function that raises
-        HookFilterException. This means that fail_silently must be set to
+        OpenEdxFilterException. This means that fail_silently must be set to
         False.
 
         Expected behavior:
@@ -65,14 +65,14 @@ class TestRunningPipeline(TestCase):
             "fail_silently": False,
         }
         exception_message = "There was an error executing filter X."
-        function = Mock(side_effect=HookFilterException(message=exception_message))
+        function = Mock(side_effect=OpenEdxFilterException(message=exception_message))
         function.__name__ = "function_name"
         get_functions_mock.return_value = [function]
-        log_message = "Exception raised while running '{func_name}':\n HookFilterException: {exc_msg}".format(
+        log_message = "Exception raised while running '{func_name}':\n OpenEdxFilterException: {exc_msg}".format(
             func_name="function_name", exc_msg=exception_message,
         )
 
-        with self.assertRaises(HookFilterException), self.assertLogs() as captured:
+        with self.assertRaises(OpenEdxFilterException), self.assertLogs() as captured:
             run_pipeline(self.filter_name, **self.kwargs)
         self.assertEqual(
             captured.records[0].getMessage(), log_message,
@@ -80,10 +80,10 @@ class TestRunningPipeline(TestCase):
 
     @patch("openedx_filters.pipeline.get_pipeline_configuration")
     @patch("openedx_filters.pipeline.get_functions_for_pipeline")
-    def test_not_raise_hook_exception(self, get_functions_mock, get_filter_config_mock):
+    def test_not_raise_filter_exception(self, get_functions_mock, get_filter_config_mock):
         """
         This method runs a pipeline with a function that raises
-        HookFilterException but raise_exception is set to False. This means
+        OpenEdxFilterException but raise_exception is set to False. This means
         fail_silently must be set to True or not defined.
 
         Expected behavior:
@@ -96,7 +96,7 @@ class TestRunningPipeline(TestCase):
         return_value = {
             "request": Mock(),
         }
-        function_with_exception = Mock(side_effect=HookFilterException)
+        function_with_exception = Mock(side_effect=OpenEdxFilterException)
         function_without_exception = Mock(return_value=return_value)
         get_functions_mock.return_value = [
             function_with_exception,

--- a/openedx_filters/utils.py
+++ b/openedx_filters/utils.py
@@ -123,7 +123,7 @@ def get_filter_config(filter_name):
                 the pipeline are defined.
                 - fail_silently (bool): determines whether the pipeline can
                 raise exceptions while executing. If its value is True then
-                exceptions (HookFilterException) are caught and the execution
+                exceptions (OpenEdxFilterException) are caught and the execution
                 continues, if False then exceptions are re-raised and the
                 execution fails.
 


### PR DESCRIPTION
**Description:** 
This PR renames HookFilterException to OpenEdxFilterException to be similar to [OpenEdxEventsException](https://github.com/eduNEXT/openedx-events/blob/71e82fcf0239537eab9c8740d464ffcb113bb111/openedx_events/exceptions.py#L6)

**JIRA:** 
Part of repository refactor: https://edunext.atlassian.net/browse/PS2021-914?atlOrigin=eyJpIjoiYWVmODliMjAzNWMyNDM3NzlhNTY2NDVlZDcxMTE1NDciLCJwIjoiaiJ9