### PR TITLE
docs: changed max-doc-length due to community recommendation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+Changed
+_______
+
+* Update doc-max-length following community recommendations.
+
 [0.2.0] - 2021-09-02
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Added

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ ignore=D001
 [pycodestyle]
 exclude = .git,.tox
 max-line-length = 120
-max-doc-length = 79
+max-doc-length = 120
 
 [pydocstyle]
 ; D101 = Missing docstring in public class


### PR DESCRIPTION
**Description:** 
This PR adds support for 120 max doc lines. Suggestion taken from: https://github.com/eduNEXT/openedx-events/pull/18#discussion_r675183610

