### PR TITLE
fix: change variables names to match repository purpose

### DIFF
--- a/docs/decisions/0002-hooks-filter-config-location.rst
+++ b/docs/decisions/0002-hooks-filter-config-location.rst
@@ -67,7 +67,7 @@ for the pipeline and any other optional setting for a filter.
 
 .. code-block:: python
 
-    HOOK_FILTERS_CONFIG = {
+    OPEN_EDX_FILTERS_CONFIG = {
         "org.openedx.lms.auth_user.filter.before_creation.v1": {
             "pipeline": [
                 "from_a_plugin.filters.filter_1",
@@ -83,7 +83,7 @@ functions to be run by the pipeline.
 
 .. code-block:: python
 
-    HOOK_FILTERS_CONFIG = {
+    OPEN_EDX_FILTERS_CONFIG = {
         "org.openedx.lms.auth_user.filter.before_creation.v1": {
             [
                 "from_a_plugin.filters.filter_1",
@@ -97,7 +97,7 @@ functions to be run by the pipeline.
 
 .. code-block:: python
 
-    HOOK_FILTERS_CONFIG = {
+    OPEN_EDX_FILTERS_CONFIG = {
         "org.openedx.lms.auth_user.filter.before_creation.v1": "from_a_plugin.filters.filter_1",
     }
 

--- a/openedx_filters/pipeline.py
+++ b/openedx_filters/pipeline.py
@@ -1,5 +1,5 @@
 """
-Pipeline runner used to execute list of functions (actions or filters).
+Pipeline runner used to execute list of functions (filters).
 """
 from logging import getLogger
 
@@ -9,7 +9,7 @@ from .utils import get_functions_for_pipeline, get_pipeline_configuration
 log = getLogger(__name__)
 
 
-def run_pipeline(hook_name, *args, **kwargs):
+def run_pipeline(filter_name, *args, **kwargs):
     """
     Execute filters in order.
 
@@ -31,8 +31,8 @@ def run_pipeline(hook_name, *args, **kwargs):
        }
 
     Arguments:
-        hook_name (str): determines which trigger we are listening to.
-        It also specifies which hook configuration defined through settings.
+        filter_name (str): determines which trigger we are listening to.
+        It also specifies which filter configuration to use.
 
     Returns:
         out (dict): accumulated outputs of the functions defined in pipeline.
@@ -49,7 +49,7 @@ def run_pipeline(hook_name, *args, **kwargs):
     information check their Github repository:
     https://github.com/python-social-auth/social-core
     """
-    pipeline, raise_exception = get_pipeline_configuration(hook_name)
+    pipeline, raise_exception = get_pipeline_configuration(filter_name)
 
     if not pipeline:
         return kwargs
@@ -75,7 +75,7 @@ def run_pipeline(hook_name, *args, **kwargs):
                 raise
         except Exception as exc:  # pylint: disable=broad-except
             # We're catching this because we don't want the core to blow up
-            # when a hook is broken. This exception will probably need some
+            # when a filter is broken. This exception will probably need some
             # sort of monitoring hooked up to it to make sure that these
             # errors don't go unseen.
             log.exception(

--- a/openedx_filters/tests/__init__.py
+++ b/openedx_filters/tests/__init__.py
@@ -1,3 +1,3 @@
 """
-Test package for filters from the Hooks Extension Framework.
+Test package for Open edX filters from the Hooks Extension Framework.
 """

--- a/openedx_filters/tests/test_pipeline.py
+++ b/openedx_filters/tests/test_pipeline.py
@@ -23,7 +23,7 @@ class TestRunningPipeline(TestCase):
             "request": Mock(),
         }
         self.pipeline = Mock()
-        self.hook_name = "openedx.service.context.location.type.vi"
+        self.filter_name = "openedx.service.context.location.type.vi"
 
     @patch("openedx_filters.pipeline.get_pipeline_configuration")
     @patch("openedx_filters.pipeline.get_functions_for_pipeline")
@@ -41,7 +41,7 @@ class TestRunningPipeline(TestCase):
         )
         get_functions_mock.return_value = []
 
-        result = run_pipeline(self.hook_name, **self.kwargs)
+        result = run_pipeline(self.filter_name, **self.kwargs)
 
         get_configuration_mock.assert_called_once_with(
             "openedx.service.context.location.type.vi",
@@ -73,14 +73,14 @@ class TestRunningPipeline(TestCase):
         )
 
         with self.assertRaises(HookFilterException), self.assertLogs() as captured:
-            run_pipeline(self.hook_name, **self.kwargs)
+            run_pipeline(self.filter_name, **self.kwargs)
         self.assertEqual(
             captured.records[0].getMessage(), log_message,
         )
 
     @patch("openedx_filters.pipeline.get_pipeline_configuration")
     @patch("openedx_filters.pipeline.get_functions_for_pipeline")
-    def test_not_raise_hook_exception(self, get_functions_mock, get_hook_config_mock):
+    def test_not_raise_hook_exception(self, get_functions_mock, get_filter_config_mock):
         """
         This method runs a pipeline with a function that raises
         HookFilterException but raise_exception is set to False. This means
@@ -89,7 +89,7 @@ class TestRunningPipeline(TestCase):
         Expected behavior:
             The pipeline does not re-raise the exception caught.
         """
-        get_hook_config_mock.return_value = (
+        get_filter_config_mock.return_value = (
             Mock(),
             False,
         )
@@ -103,14 +103,14 @@ class TestRunningPipeline(TestCase):
             function_without_exception,
         ]
 
-        result = run_pipeline(self.hook_name, **self.kwargs)
+        result = run_pipeline(self.filter_name, **self.kwargs)
 
         self.assertDictEqual(result, return_value)
         function_without_exception.assert_called_once_with(**self.kwargs)
 
     @patch("openedx_filters.pipeline.get_pipeline_configuration")
     @patch("openedx_filters.pipeline.get_functions_for_pipeline")
-    def test_not_raise_common_exception(self, get_functions_mock, get_hook_config_mock):
+    def test_not_raise_common_exception(self, get_functions_mock, get_filter_config_mock):
         """
         This method runs a pipeline with a function that raises a
         common Exception.
@@ -118,7 +118,7 @@ class TestRunningPipeline(TestCase):
         Expected behavior:
             The pipeline continues execution after caughting Exception.
         """
-        get_hook_config_mock.return_value = (
+        get_filter_config_mock.return_value = (
             self.pipeline,
             True,
         )
@@ -138,7 +138,7 @@ class TestRunningPipeline(TestCase):
         )
 
         with self.assertLogs() as captured:
-            result = run_pipeline(self.hook_name, **self.kwargs)
+            result = run_pipeline(self.filter_name, **self.kwargs)
 
         self.assertEqual(
             captured.records[0].getMessage(), log_message,
@@ -148,14 +148,14 @@ class TestRunningPipeline(TestCase):
 
     @patch("openedx_filters.pipeline.get_pipeline_configuration")
     @patch("openedx_filters.pipeline.get_functions_for_pipeline")
-    def test_getting_pipeline_result(self, get_functions_mock, get_hook_config_mock):
+    def test_getting_pipeline_result(self, get_functions_mock, get_filter_config_mock):
         """
         This method runs a pipeline with functions defined via configuration.
 
         Expected behavior:
             Returns the processed dictionary.
         """
-        get_hook_config_mock.return_value = (
+        get_filter_config_mock.return_value = (
             self.pipeline,
             True,
         )
@@ -173,7 +173,7 @@ class TestRunningPipeline(TestCase):
             second_function,
         ]
 
-        result = run_pipeline(self.hook_name, **self.kwargs)
+        result = run_pipeline(self.filter_name, **self.kwargs)
 
         first_function.assert_called_once_with(**self.kwargs)
         second_function.assert_called_once_with(**return_value_1st)
@@ -181,7 +181,7 @@ class TestRunningPipeline(TestCase):
 
     @patch("openedx_filters.pipeline.get_pipeline_configuration")
     @patch("openedx_filters.pipeline.get_functions_for_pipeline")
-    def test_partial_pipeline(self, get_functions_mock, get_hook_config_mock):
+    def test_partial_pipeline(self, get_functions_mock, get_filter_config_mock):
         """
         This method runs a pipeline with functions defined via configuration.
         At some point, returns an object to stop execution.
@@ -189,7 +189,7 @@ class TestRunningPipeline(TestCase):
         Expected behavior:
             Returns the object used to stop execution.
         """
-        get_hook_config_mock.return_value = (
+        get_filter_config_mock.return_value = (
             self.pipeline,
             True,
         )
@@ -204,7 +204,7 @@ class TestRunningPipeline(TestCase):
         log_message = "Pipeline stopped by 'first_function' for returning an object."
 
         with self.assertLogs() as captured:
-            result = run_pipeline(self.hook_name, **self.kwargs)
+            result = run_pipeline(self.filter_name, **self.kwargs)
 
         self.assertEqual(
             captured.records[0].getMessage(), log_message,

--- a/openedx_filters/tests/test_utils.py
+++ b/openedx_filters/tests/test_utils.py
@@ -102,21 +102,21 @@ class TestUtilityFunctions(TestCase):
 
         self.assertEqual(function_list, [test_function] * 2)
 
-    def test_get_empty_hook_config(self):
+    def test_get_empty_filter_config(self):
         """
         This method is used to verify the behavior of
         get_filter_config when a trigger without a
-        HOOKS_FILTER_CONFIG is passed as parameter.
+        OPEN_EDX_FILTERS_CONFIG is passed as parameter.
 
         Expected behavior:
             Returns an empty dictionary.
         """
-        result = get_filter_config("hook_name")
+        result = get_filter_config("filter_name")
 
         self.assertEqual(result, {})
 
     @override_settings(
-        HOOK_FILTERS_CONFIG={
+        OPEN_EDX_FILTERS_CONFIG={
             "openedx.service.context.location.type.vi": {
                 "pipeline": [
                     "openedx_filters.tests.test_utils.test_function",
@@ -126,11 +126,11 @@ class TestUtilityFunctions(TestCase):
             }
         }
     )
-    def test_get_hook_config(self):
+    def test_get_filter_config(self):
         """
         This method is used to verify the behavior of
         get_filter_config when a trigger with
-        HOOKS_FILTER_CONFIG defined is passed as parameter.
+        OPEN_EDX_FILTERS_CONFIG defined is passed as parameter.
 
         Expected behavior:
             Returns a tuple with pipeline configurations.
@@ -190,7 +190,7 @@ class TestUtilityFunctions(TestCase):
         """
         This method is used to verify the behavior of
         get_pipeline_configuration when a trigger with
-        HOOKS_FILTER_CONFIG defined is passed as parameter.
+        OPEN_EDX_FILTERS_CONFIG defined is passed as parameter.
 
         Expected behavior:
             Returns a tuple with the pipeline and exception handling
@@ -198,6 +198,6 @@ class TestUtilityFunctions(TestCase):
         """
         get_filter_config_mock.return_value = config
 
-        result = get_pipeline_configuration("hook_name")
+        result = get_pipeline_configuration("filter_name")
 
         self.assertTupleEqual(result, expected_result)

--- a/openedx_filters/utils.py
+++ b/openedx_filters/utils.py
@@ -1,5 +1,5 @@
 """
-Utilities for the hooks module.
+Utilities for the Open edX Filters module.
 """
 from logging import getLogger
 
@@ -47,7 +47,7 @@ def get_functions_for_pipeline(pipeline):
     return function_list
 
 
-def get_pipeline_configuration(hook_name):
+def get_pipeline_configuration(filter_name):
     """
     Get pipeline configuration from filter settings.
 
@@ -66,7 +66,7 @@ def get_pipeline_configuration(hook_name):
             )
 
     Arguments:
-        hook_name (str): determines which is the trigger of this
+        filter_name (str): determines which is the trigger of this
         pipeline.
 
     Returns:
@@ -77,29 +77,29 @@ def get_pipeline_configuration(hook_name):
         fail_silently configuration, True meaning it won't raise exceptions and
         False the opposite.
     """
-    hook_config = get_filter_config(hook_name)
+    filter_config = get_filter_config(filter_name)
 
-    if not hook_config:
+    if not filter_config:
         return [], False
 
     pipeline, raise_exception = [], False
 
-    if isinstance(hook_config, dict):
+    if isinstance(filter_config, dict):
         pipeline, raise_exception = (
-            hook_config.get("pipeline", []),
-            not hook_config.get("fail_silently", True),
+            filter_config.get("pipeline", []),
+            not filter_config.get("fail_silently", True),
         )
 
-    elif isinstance(hook_config, list):
-        pipeline = hook_config
+    elif isinstance(filter_config, list):
+        pipeline = filter_config
 
-    elif isinstance(hook_config, str):
-        pipeline.append(hook_config)
+    elif isinstance(filter_config, str):
+        pipeline.append(filter_config)
 
     return pipeline, raise_exception
 
 
-def get_filter_config(hook_name):
+def get_filter_config(filter_name):
     """
     Get filters configuration from settings.
 
@@ -128,12 +128,12 @@ def get_filter_config(hook_name):
                 execution fails.
 
     Arguments:
-        hook_name (str): determines which configuration to use.
+        filter_name (str): determines which configuration to use.
 
     Returns:
-        hooks configuration (dict): taken from Django settings
-        containing hooks configuration.
+        filters configuration (dict): taken from Django settings
+        containing filters configuration.
     """
-    hooks_config = getattr(settings, "HOOK_FILTERS_CONFIG", {})
+    filters_config = getattr(settings, "OPEN_EDX_FILTERS_CONFIG", {})
 
-    return hooks_config.get(hook_name, {})
+    return filters_config.get(filter_name, {})


### PR DESCRIPTION
**Description:** 
This PR changes _hook_ to _filter_ and standardizes the configuration name.