### PR TITLE
fix: remove "OpenEdxFilterException:" from exception str repr

### DIFF
--- a/openedx_filters/exceptions.py
+++ b/openedx_filters/exceptions.py
@@ -35,4 +35,4 @@ class OpenEdxFilterException(Exception):
         """
         Show string representation of OpenEdxFilterException using its message.
         """
-        return "OpenEdxFilterException: {}".format(self.message)
+        return self.message


### PR DESCRIPTION
**Description**
This PR changes the string representation for filters exceptions.

Before
![image](https://user-images.githubusercontent.com/64440265/143607262-02095980-16e5-4fae-ad9a-1abba627726a.png)
```
  File "/edx/src/openedx-filters/openedx_filters/tooling.py", line 211, in run_pipeline
    result = step_runner.run(**accumulated_output)
  File "/edx/src/openedx-filters-test-plugin/openedx_filters_test_plugin/pipeline.py", line 146, in run
    raise PreLoginFilter.PreventLogin("You can't login on this site.")
openedx_filters.learning.auth.PreLoginFilter.PreventLogin: OpenEdxFilterException: You can't login on this site.
```
After
![image](https://user-images.githubusercontent.com/64440265/143607554-267938d2-35c8-4d0b-9f98-690f25a47dee.png)
```
  File "/edx/src/openedx-filters/openedx_filters/tooling.py", line 211, in run_pipeline
    result = step_runner.run(**accumulated_output)
  File "/edx/src/openedx-filters-test-plugin/openedx_filters_test_plugin/pipeline.py", line 146, in run
    raise PreLoginFilter.PreventLogin("You can't login on this site.")
openedx_filters.learning.auth.PreLoginFilter.PreventLogin: You can't login on this site.
```
