### PR TITLE
 feat: add 2nd batch of filters

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,15 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+Added
+_____
+
+* Unenrollment filter definition.
+* Certificate creation/rendering filters.
+* Dashboard render filter definition.
+* Course home/about render filters.
+* Cohort change filter.
+
 [0.4.3] - 2022-01-24
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/openedx_filters/learning/filters.py
+++ b/openedx_filters/learning/filters.py
@@ -8,7 +8,7 @@ from openedx_filters.utils import SensitiveDataManagementMixin
 
 class StudentRegistrationRequested(OpenEdxPublicFilter, SensitiveDataManagementMixin):
     """
-    Custom class used to create PreRegister filters.
+    Custom class used to create registration filters and its custom methods.
     """
 
     filter_type = "org.openedx.learning.student.registration.requested.v1"
@@ -39,7 +39,7 @@ class StudentRegistrationRequested(OpenEdxPublicFilter, SensitiveDataManagementM
 
 class StudentLoginRequested(OpenEdxPublicFilter):
     """
-    Custom class used to create PreLogin filters.
+    Custom class used to create login filters and its custom methods.
     """
 
     filter_type = "org.openedx.learning.student.login.requested.v1"
@@ -69,7 +69,7 @@ class StudentLoginRequested(OpenEdxPublicFilter):
 
 class CourseEnrollmentStarted(OpenEdxPublicFilter):
     """
-    Custom class used to create PreEnrollment filters.
+    Custom class used to create enrollment filters and its custom methods.
     """
 
     filter_type = "org.openedx.learning.course.enrollment.started.v1"
@@ -86,10 +86,208 @@ class CourseEnrollmentStarted(OpenEdxPublicFilter):
 
         Arguments:
             user (User): is a Django User object.
-            course_key (CourseKey): name of the filter.
+            course_key (CourseKey): course key associated with the enrollment.
             mode (str): is a string specifying what kind of enrollment.
         """
         data = super().run_pipeline(
             user=user, course_key=course_key, mode=mode,
         )
         return data.get("user"), data.get("course_key"), data.get("mode")
+
+
+class CourseUnenrollmentStarted(OpenEdxPublicFilter):
+    """
+    Custom class used to create unenrollment filters and its custom methods.
+    """
+
+    filter_type = "org.openedx.learning.course.unenrollment.started.v1"
+
+    class PreventUnenrollment(OpenEdxFilterException):
+        """
+        Custom class used to stop the unenrollment process.
+        """
+
+    @classmethod
+    def run_filter(cls, enrollment):
+        """
+        Execute a filter with the signature specified.
+
+        Arguments:
+            enrollment (CourseEnrollment): edxapp object representing course enrollments.
+        """
+        data = super().run_pipeline(enrollment=enrollment)
+        return data.get("enrollment")
+
+
+class CertificateCreationRequested(OpenEdxPublicFilter):
+    """
+    Custom class used to create certificate creation filters and its custom methods.
+    """
+
+    filter_type = "org.openedx.learning.certificate.creation.requested.v1"
+
+    class PreventCertificateCreation(OpenEdxFilterException):
+        """
+        Custom class used to stop the certificate creation process.
+        """
+
+    @classmethod
+    def run_filter(cls, user, course_id, mode, status):
+        """
+        Execute a filter with the signature specified.
+
+        Arguments:
+            user (User): is a Django User object.
+            course_id (CourseKey): course key associated with the certificate.
+            mode (str): mode of the certificate.
+            status (str): status of the certificate.
+        """
+        data = super().run_pipeline(
+            user=user, course_id=course_id, mode=mode, status=status,
+        )
+        return data.get("user"), data.get("course_id"), data.get("mode"), data.get("status")
+
+
+class CertificateRenderStarted(OpenEdxPublicFilter):
+    """
+    Custom class used to create certificate render filters and its custom methods.
+    """
+
+    filter_type = "org.openedx.learning.certificate.render.started.v1"
+
+    class PreventCertificateRender(OpenEdxFilterException):
+        """
+        Custom class used to stop the certificate rendering process.
+        """
+
+    @classmethod
+    def run_filter(cls, context, custom_template):
+        """
+        Execute a filter with the signature specified.
+
+        Arguments:
+            context (dict): context dictionary for certificate template.
+            custom_template (CertificateTemplate): edxapp object representing custom web
+            certificate template.
+        """
+        data = super().run_pipeline(context=context, custom_template=custom_template)
+        return data.get("context"), data.get("custom_template")
+
+
+class CohortChangeRequested(OpenEdxPublicFilter):
+    """
+    Custom class used to create cohort change filters and its custom methods.
+    """
+
+    filter_type = "org.openedx.learning.cohort.change.requested.v1"
+
+    class PreventCohortChange(OpenEdxFilterException):
+        """
+        Custom class used to stop the cohort change process.
+        """
+
+    @classmethod
+    def run_filter(cls, current_membership, target_cohort):
+        """
+        Execute a filter with the signature specified.
+
+        Arguments:
+            current_membership (CohortMembership): edxapp object representing the user's cohort
+            current membership object.
+            target_cohort (CourseUserGroup): edxapp object representing the new user's cohort.
+        """
+        data = super().run_pipeline(current_membership=current_membership, target_cohort=target_cohort)
+        return data.get("current_membership"), data.get("target_cohort")
+
+
+class CourseAboutRenderStarted(OpenEdxPublicFilter):
+    """
+    Custom class used to create course about render filters and its custom methods.
+    """
+
+    filter_type = "org.openedx.learning.course_about.render.started.v1"
+
+    class PreventCourseAboutRender(OpenEdxFilterException):
+        """
+        Custom class used to stop the course about rendering process.
+        """
+
+        def __init__(self, message, redirect_to=None):
+            """
+            Override init that defines specific arguments used in the course about render process.
+            """
+            super().__init__(message, redirect_to=redirect_to)
+
+    @classmethod
+    def run_filter(cls, context, template_name):
+        """
+        Execute a filter with the signature specified.
+
+        Arguments:
+            context (dict): context dictionary for course about template.
+            template_name (str): certificate name to be rendered by the course about.
+        """
+        data = super().run_pipeline(context=context, template_name=template_name)
+        return data.get("context"), data.get("template_name")
+
+
+class CourseHomeRenderStarted(OpenEdxPublicFilter):
+    """
+    Custom class used to create course home render filters and its custom methods.
+    """
+
+    filter_type = "org.openedx.learning.course_home.render.started.v1"
+
+    class PreventCourseHomeRender(OpenEdxFilterException):
+        """
+        Custom class used to stop the course home render process.
+        """
+
+        def __init__(self, message, redirect_to=None):
+            """
+            Override init that defines specific arguments used in the course home render process.
+            """
+            super().__init__(message, redirect_to=redirect_to)
+
+    @classmethod
+    def run_filter(cls, context, template_name):
+        """
+        Execute a filter with the signature specified.
+
+        Arguments:
+            context (dict): context dictionary for course home template.
+            template_name (str): certificate name to be rendered by the course home.
+        """
+        data = super().run_pipeline(context=context, template_name=template_name)
+        return data.get("context"), data.get("template_name")
+
+
+class DashboardRenderStarted(OpenEdxPublicFilter):
+    """
+    Custom class used to create dashboard render filters and its custom methods.
+    """
+
+    filter_type = "org.openedx.learning.dashboard.render.started.v1"
+
+    class PreventDashboardRender(OpenEdxFilterException):
+        """
+        Custom class used to stop the dashboard render process.
+        """
+
+        def __init__(self, message, redirect_to=None):
+            """
+            Override init that defines specific arguments used in the dashboard render process.
+            """
+            super().__init__(message, redirect_to=redirect_to)
+
+    @classmethod
+    def run_filter(cls, context, template_name):
+        """
+        Execute a filter with the signature specified.
+
+        Arguments:
+            context (dict): context dictionary for student's dashboard template.
+            template_name (str): certificate name to be rendered by the student's dashboard.
+        """
+        data = super().run_pipeline(context=context, template_name=template_name)
+        return data.get("context"), data.get("template_name")


### PR DESCRIPTION
## Description

This PR adds:

- CourseUnenrollmentStarted: intended to be executed before the un-enrollment process starts.
- CertificateCreationRequested: intended to be executed before the certificate creation process starts.
- CertificateRenderStarted: intended to be executed before the certificate template rendering process starts.
- CohortChangeRequested: intended to be executed before the cohort change process starts.
- CourseAboutRenderStarted:  intended to be executed before course about template render starts.
- CourseHomeRenderStarted: intended to be executed before course home template render starts.
- DashboardRenderStarted: intended to be executed before the student's dashboard render starts.

Used by edx-platform.

**Testing instructions:**

Follow instructions in [PR 29840](https://github.com/openedx/edx-platform/pull/29840)

**Reviewers:**
- [x] @felipemontoya 

**Merge checklist:**
- [ ] All reviewers approved
- [x] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:**
None. Please feel free to post yours!
