### PR TITLE
refactor: add fail_silently flag when importing pipeline steps

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+Changed
+_______
+
+* Add fail_silently when importing filter steps.
+
 [0.4.2] - 2021-12-16
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/openedx_filters/tooling.py
+++ b/openedx_filters/tooling.py
@@ -25,7 +25,7 @@ class OpenEdxPublicFilter:
         return "<OpenEdxPublicFilter: {filter_type}>".format(filter_type=self.filter_type)
 
     @classmethod
-    def get_steps_for_pipeline(cls, pipeline):
+    def get_steps_for_pipeline(cls, pipeline, fail_silently):
         """
         Get pipeline objects from paths.
 
@@ -48,6 +48,8 @@ class OpenEdxPublicFilter:
 
         Arguments:
             pipeline (list): paths where steps are defined.
+            fail_silently (bool): True meaning it won't raise exceptions and
+            False the opposite.
 
         Returns:
             step_list (list): class objects defined in pipeline.
@@ -58,7 +60,10 @@ class OpenEdxPublicFilter:
                 function = import_string(step_path)
                 step_list.append(function)
             except ImportError:
-                log.exception("Failed to import '%s'.", step_path)
+                log.exception("Failed to import: '%s'", step_path)
+                if fail_silently:
+                    continue
+                raise
 
         return step_list
 
@@ -198,7 +203,7 @@ class OpenEdxPublicFilter:
         if not pipeline:
             return kwargs
 
-        steps = cls.get_steps_for_pipeline(pipeline)
+        steps = cls.get_steps_for_pipeline(pipeline, fail_silently)
         filter_metadata = {
             "filter_type": cls.filter_type,
             "running_pipeline": pipeline,


### PR DESCRIPTION
**Description:** 
This PR adds `fail_silently` when importing pipeline steps when running a filter pipeline.

**Testing instructions:**
1. Use these settings without installing the `openedx_filters_samples.samples` 
```
OPEN_EDX_FILTERS_CONFIG = {
    "org.openedx.learning.student.login.requested.v1": {
        "fail_silently": False,
        "pipeline": [
            "openedx_filters_samples.samples.pipeline.ModifyUserProfileBeforeLogin",
            "openedx_filters_samples.samples.pipeline.StopLogin"
        ]
    },
}
```
2. Then, login. The application should crash. 
3. Change `fail_silently` to `True`. Login again, the application should continue its execution as usual.

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [ ] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)
